### PR TITLE
Updated ./src/deploy/env/prod to use new image

### DIFF
--- a/manifests.yaml
+++ b/manifests.yaml
@@ -2,7 +2,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:
-    app.kubernetes.io/version: 1.0.77
+    app.kubernetes.io/version: 1.0.98
     rollouts-app/stage: prod
   name: rollouts-app
   namespace: demo-prod
@@ -16,7 +16,7 @@ spec:
     metadata:
       labels:
         app: rollouts-app
-        app.kubernetes.io/version: 1.0.77
+        app.kubernetes.io/version: 1.0.98
         rollouts-app/stage: prod
     spec:
       containers:
@@ -33,7 +33,7 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
-        image: ghcr.io/eddiewebb/rollouts:1.0.77
+        image: ghcr.io/eddiewebb/rollouts:1.0.98
         name: rollouts-app
         ports:
         - containerPort: 8080


### PR DESCRIPTION

- ghcr.io/eddiewebb/rollouts:1.0.98[skip ci]
